### PR TITLE
Provide full user agents and randomly 'rotate' them

### DIFF
--- a/src/fear_and_greed/cnn.py
+++ b/src/fear_and_greed/cnn.py
@@ -18,16 +18,16 @@ requests_cache.install_cache(
 URL = "https://production.dataviz.cnn.io/index/fearandgreed/graphdata"
 
 USER_AGENTS = [
-  # Chrome on Windows 10
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
-  # Chrome on macOS
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
-  # Chrome on Linux
-  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
-  # Firefox on Windows
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0",
-  # Firefox on Macos
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 12.4; rv:100.0) Gecko/20100101 Firefox/100.0",
+    # Chrome on Windows 10
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
+    # Chrome on macOS
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
+    # Chrome on Linux
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
+    # Firefox on Windows
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0",
+    # Firefox on Macos
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 12.4; rv:100.0) Gecko/20100101 Firefox/100.0",
 ]
 
 

--- a/src/fear_and_greed/cnn.py
+++ b/src/fear_and_greed/cnn.py
@@ -8,12 +8,27 @@ import typing
 import requests
 import requests_cache
 
+from random import choice
+
 requests_cache.install_cache(
     cache_name=os.path.join(tempfile.gettempdir(), "cnn_cache"),
     expire_after=datetime.timedelta(minutes=1),
 )
 
 URL = "https://production.dataviz.cnn.io/index/fearandgreed/graphdata"
+
+USER_AGENTS = [
+  # Chrome on Windows 10
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
+  # Chrome on macOS
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
+  # Chrome on Linux
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
+  # Firefox on Windows
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0",
+  # Firefox on Macos
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 12.4; rv:100.0) Gecko/20100101 Firefox/100.0",
+]
 
 
 class FearGreedIndex(typing.NamedTuple):
@@ -26,8 +41,9 @@ class Fetcher:
     """Fetcher gets the HTML contents of CNN's Fear & Greed Index website."""
 
     def __call__(self) -> dict:
+        user_agent = choice(USER_AGENTS)
         headers = {
-            "User-Agent": "Mozilla",
+            "User-Agent": user_agent,
         }
         r = requests.get(URL, headers=headers)
         r.raise_for_status()


### PR DESCRIPTION
Unfortunately the cnn-website now also checks for reasonable user agents.
A
```python
import requests
URL = "https://production.dataviz.cnn.io/index/fearandgreed/graphdata"

user_agent = "Mozilla"

headers = {
    "User-Agent": user_agent,
}
r = requests.get(URL, headers=headers)
r.raise_for_status()
```
stopped working.

This MR now provide full user agents and randomly 'rotate' them as suggested in #17.


I think external users could troubleshoot via https://stackoverflow.com/a/16630836.
Instead of a hard-coded list you could also use python-latest-user-agents, but that just uses a [json file](https://github.com/jnrbsn/python-latest-user-agents/blob/361d690612b21fa67b1232ef4e4e87c48a6daaf5/latest_user_agents.py#L12) so I'm not sure if the entire "we create a database and depend on complex code" is worth for a simple json.